### PR TITLE
Avoid using the quote character (") in our chunk encoding.

### DIFF
--- a/client/js/chunks/worker/main.js
+++ b/client/js/chunks/worker/main.js
@@ -75,9 +75,11 @@ function processChunk(payload) {
 	//into indices in this array.
 	var blocks = new Uint8Array(data.length);
 	for (var i = 0; i < blocks.length; i++) {
-		// 32 - Space character. Control characters
-		// are not allowed in JSON strings.
-		blocks[i] = data.charCodeAt(i) - 32;
+		// 35: # charater. Control charaters
+		// are not allowed in JSON strings, and
+		// we want to avoid '"', which requires
+		// escaping.
+		blocks[i] = data.charCodeAt(i) - 35;
 	}
 
 	var chunk = manager.get(cc);

--- a/client/js/player/inventory.js
+++ b/client/js/player/inventory.js
@@ -45,7 +45,11 @@ function Inventory(world, camera, conn, controls) {
 	conn.on('inventory-state', function (payload) {
 		var items = new Uint8Array(payload.Items.length);
 		for (var i = 0; i < items.length; i++) {
-			items[i] = payload.Items.charCodeAt(i) - 32;
+			// 35: # charater. Control charaters
+			// are not allowed in JSON strings, and
+			// we want to avoid '"', which requires
+			// escaping.
+			items[i] = payload.Items.charCodeAt(i) - 35;
 		}
 
 		var oldLeft = leftStack();

--- a/lib/game/inventory.go
+++ b/lib/game/inventory.go
@@ -118,10 +118,12 @@ func (inv *Inventory) ItemsToString() string {
 }
 
 func toStringByte(val byte) byte {
-	// 32: Space charater. Control charaters
-	// are not allowed in JSON strings.
-	value := val + 32
-	if value >= 127 || value < 32 {
+	// 35: # charater. Control charaters
+	// are not allowed in JSON strings, and
+	// we want to avoid '"', which requires
+	// escaping.
+	value := val + 35
+	if value >= 127 || value < 35 {
 		panic(fmt.Sprintf("Attempted to encode out of range value of '%d' to item data. (It might work but we need to test it)", value))
 	}
 	return value

--- a/lib/mapgen/chunk.go
+++ b/lib/mapgen/chunk.go
@@ -64,10 +64,12 @@ func (c Chunk) Flatten() string {
 	for ocX := 0; ocX < cw; ocX++ {
 		for ocY := 0; ocY < ch; ocY++ {
 			for ocZ := 0; ocZ < cd; ocZ++ {
-				// 32: Space charater. Control charaters
-				// are not allowed in JSON strings.
-				value := byte(c[ocX][ocY][ocZ] + 32)
-				if value >= 127 || value < 32 {
+				// 35: # charater. Control charaters
+				// are not allowed in JSON strings, and
+				// we want to avoid '"', which requires
+				// escaping.
+				value := byte(c[ocX][ocY][ocZ] + 35)
+				if value >= 127 || value < 35 {
 					panic(fmt.Sprintf("Attempted to encode out of range value of '%d' to chunk data. (It might work but we need to test it)", value))
 				}
 				data[ocX*cw*ch+ocY*cw+ocZ] = value


### PR DESCRIPTION
This quote character requires escaping in JSON strings, and using
it for BLOCK_DIRT was causing the average chunk to be somewhere on
the order of ~50kb. This patch corrects that problem by increasing
the lower number to above that of a quotation mark, reducing the
average chunk size back to ~33kb. Ideally we will apply compression
and base64 in the future for even more space savings, but that's a
bit more involved (see https://github.com/crazy2be/compression-tests)

Also see http://www.asciitable.com/ for ascii codes
