### PR TITLE
Catch pre-boot (i.e. probably requirejs) errors and display them to the user

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,6 @@
 		<link rel="stylesheet" href="css/chat.css" />
 		<link rel="stylesheet" href="css/health.css" />
 		<link rel="stylesheet" href="css/splash.css" />
-		<script data-main="js/boot.js" src="lib/require.js"></script>
 	</head>
 	<body class="no-select">
 		<div id="container">
@@ -57,5 +56,13 @@
 				</div>
 			</div>
 		</div>
+		<script>
+			window.onerror = function (msg, url, lineno) {
+				alert("FATAL PRE-BOOT ERROR:\n" + 
+					msg + "\n" +
+					"(" + url + ":" + lineno + ")");
+			};
+		</script>
+		<script data-main="js/boot.js" src="lib/require.js"></script>
 	</body>
 </html>

--- a/client/js/boot.js
+++ b/client/js/boot.js
@@ -1,4 +1,4 @@
-﻿requirejs.config({
+requirejs.config({
 	//We need paths because min files are annoying to handle with magicWrapper...
 	paths: {
 		THREE: '/lib/three',
@@ -30,7 +30,7 @@
 	}],
 });
 
-define(["main", "settings", "math", "fatalError", "debug", "THREE"], function(main, __loadSettingsScheme, mathFnc, fatalError, debug, THREE) {
+require(["main", "settings", "math", "fatalError", "debug", "THREE"], function(main, __loadSettingsScheme, math, fatalError, debug, THREE) {
 	THREE.DVector3 = debug.DVector3;
 
 	window.onerror = function (msg, url, lineno) {
@@ -41,7 +41,16 @@ define(["main", "settings", "math", "fatalError", "debug", "THREE"], function(ma
 		});
 	};
 
-	mathFnc(self);
-	self.__loadSettingsScheme = __loadSettingsScheme;
+	// Make all the math convenience functions global, so you can
+	// do abs(a) rather than Math.abs(a).
+	merge(window, math);
+	window.__loadSettingsScheme = __loadSettingsScheme;
 	main();
+	
+	function merge(obj, newProperties) {
+		for (var k in newProperties) {
+			obj[k] = newProperties[k];
+		}
+	}
 });
+

--- a/client/js/chunks/worker/boot.js
+++ b/client/js/chunks/worker/boot.js
@@ -25,13 +25,21 @@ requirejs.config({
 	},
 });
 
-require(["main", "math"], function (main, mathFnc) {
-	mathFnc(self);
+require(["main", "math"], function (main, math) {
+	// Make all the math convenience functions global, so you can
+	// do abs(a) rather than Math.abs(a).
+	merge(self, math);
 
-	//No need to call anything, just including main should do it...
+	// No need to call anything, just including main should do it...
 	console.log("Booted successfully");
 	parent.postMessage({
 		kind: "booted",
 		payload: "success",
 	});
+	
+	function merge(obj, newProperties) {
+		for (var k in newProperties) {
+			obj[k] = newProperties[k];
+		}
+	}
 });

--- a/client/js/chunks/worker/main.js
+++ b/client/js/chunks/worker/main.js
@@ -10,10 +10,6 @@ var WorkerChunkManager = require("workerChunkManager");
 
 var Conn = require("conn");
 
-// I use self for other things. Parent makes
-// a lot more sense anyway.
-var parent = self;
-
 function sendChunk() {
 	var chunk = manager.top();
 	if (!chunk) return;

--- a/client/js/math.js
+++ b/client/js/math.js
@@ -1,36 +1,32 @@
-//Exposes handy math functions to the global context
-
+// Handy math functions!
 define(function() {
-return function addToContext(context) {
-	//I swear, I should just loop through all of math and add it to the global context...
-	context.sin = Math.sin;
-	context.cos = Math.cos;
-	context.abs = Math.abs;
-	context.min = Math.min;
-	context.max = Math.max;
-	context.sqrt = Math.sqrt;
-	context.pow = Math.pow;
-	context.floor = Math.floor;
-	context.ceil = Math.ceil;
+math = {};
+math.sin = Math.sin;
+math.cos = Math.cos;
+math.abs = Math.abs;
+math.min = Math.min;
+math.max = Math.max;
+math.sqrt = Math.sqrt;
+math.pow = Math.pow;
+math.floor = Math.floor;
+math.ceil = Math.ceil;
 
-	//Well this stuff should probably go in a module... but this is
-	//soooo convienent!
-	context.mod = function (a, b) {
-		return (((a % b) + b) % b);
-	}
-	// Clamp n between [a, b]. Behaviour is
-	// undefined if a > b. (who even wrote this?)
-	context.clamp = function (n, a, b) {
-		return n < a ? a : n > b ? b : n;
-	}
-	// Return the sign of n, -1, 1, or 0.
-	context.signum = function (n) {
-		return n < 0 ? -1 : n > 0 ? 1 : 0;
-	}
-	// You only need this on the worker thread,
-	//
-	context.dist = function (p1, p2) {
-		return sqrt(pow(p1.x - p2.x, 2) + pow(p1.y - p2.y, 2) + pow(p1.z - p2.z, 2));
-	}
+// JavaScript builtin mod is silly for negative numbers...
+math.mod = function (a, b) {
+	return (((a % b) + b) % b);
 }
+// Clamp n between [a, b]. Behaviour is
+// undefined if a > b. (who even wrote this?)
+math.clamp = function (n, a, b) {
+	return n < a ? a : n > b ? b : n;
+}
+// Return the sign of n, -1, 1, or 0.
+math.signum = function (n) {
+	return n < 0 ? -1 : n > 0 ? 1 : 0;
+}
+// Euclidian distance between p1 and p2
+math.dist = function (p1, p2) {
+	return sqrt(pow(p1.x - p2.x, 2) + pow(p1.y - p2.y, 2) + pow(p1.z - p2.z, 2));
+}
+return math;
 });


### PR DESCRIPTION
This lets the user know that things are broken, and that they should probably
not bother waiting any longer. I was originally planning to use fatalError for
this, but then we would need to have a require statement which loaded
fatalError (and _just_ fatalError, lest there was a load error for one of the
other modules), assigns window.onError, and then loads the remaining modules
required for boot-up. And this still wouldn't catch, say, an error when the
fatalError module itself is loaded, or when requirejs is loaded. This solution
catches all such errors immediately.

Ideally such errors should never occur in production anyway, and if they _do_,
it means we've done something really wrong.

Fixes #142
