### PR TITLE
Fix inventory block jumping when rearrangement drag started.

### DIFF
--- a/client/js/player/inventory.js
+++ b/client/js/player/inventory.js
@@ -85,7 +85,6 @@ function Inventory(world, camera, conn, controls) {
 			$(this).children("div").draggable({
 				helper: "clone",
 				appendTo: "body",
-				containment: "body",
 				scroll: false,
 				start: function (event, ui) {
 					$(this).attr("index", index);


### PR DESCRIPTION
Previously, when you started dragging an item in your inventory in
order to rearrage it, the item sprite would immediately jump
offscreen and out of view. This was not purely a visual / offset
bug, as the item could not be dropped by differental movement.

It appears the reason for this is that the body element at some
point became 0 height rather than the height of the content. Given
that the draggable UI library was set to contain the draggable
inventory item to the body, this resulted in the draggable inventory
item jumping to try and be contained in this zero-height element.

This change fixes this by no longer containing the inventory element
within the body. This doesn't seem useful / necessary anyway, as
the game is always fullscreen anyway.